### PR TITLE
Disabling HTTPS cert check that prevents model download

### DIFF
--- a/dostoevsky/data/__init__.py
+++ b/dostoevsky/data/__init__.py
@@ -1,5 +1,6 @@
 import os
 import lzma
+import ssl
 import typing
 import tarfile
 import urllib.request
@@ -26,7 +27,7 @@ class DataDownloader:
         url: str = os.path.join(STORAGE_BASE_URL, source)
         request = urllib.request.Request(url)
         request.add_header('User-Agent', self.USERAGENT)
-        response = urllib.request.urlopen(request)
+        response = urllib.request.urlopen(request, context=self._ssl_context())
         with open(destination_path, 'wb') as output:
             filesize: int = 0
             while source:
@@ -40,3 +41,10 @@ class DataDownloader:
             with tarfile.open(fileobj=f) as tar:
                 tar.extractall(os.path.dirname(destination_path))
         return filesize
+
+    @staticmethod
+    def _ssl_context() -> ssl.SSLContext:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx


### PR DESCRIPTION
Receiving the following error when trying to download the model in the empty environment.

Steps to reproduce with venv:
```bash
➜  dostoevsky git:(master) virtualenv --python python3.8 ./venv
Already using interpreter /Library/Frameworks/Python.framework/Versions/3.8/bin/python3.8
Using base prefix '/Library/Frameworks/Python.framework/Versions/3.8'
New python executable in /Users/anthony/PycharmProjects/dostoevsky/venv/bin/python3.8
Also creating executable in /Users/anthony/PycharmProjects/dostoevsky/venv/bin/python
Installing setuptools, pip, wheel...
done.

➜  dostoevsky git:(master) source venv/bin/activate

(venv) ➜  dostoevsky git:(master) python -m dostoevsky download fasttext-social-network-model
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 1317, in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1230, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1276, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1225, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1004, in _send_output
    self.send(msg)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 944, in send
    self.connect()
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1399, in connect
    self.sock = self._context.wrap_socket(self.sock,
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1108)
```

Disabling certificate check during the model download that caused SSL verification error without installing additional packages (e.g. certifi, etc)